### PR TITLE
engineering parsing 2021-2022 fix

### DIFF
--- a/ProgramParsing/Engineering/MajorParser2021_2022.py
+++ b/ProgramParsing/Engineering/MajorParser2021_2022.py
@@ -40,6 +40,8 @@ class EngineeringMajorParser2021_2022(MajorParser):
         if line.startswith("Note") or line.startswith("("):
             return []
 
+        if "WKRPT" in line or "ECE 101" in line:
+            return []
 
         rangeCourse = re.findall(r"[A-Z]+\s{0,1}[1-9][0-9][0-9]\s{0,1}-\s{0,1}[A-Z]+\s{0,1}[1-9][0-9][0-9]",
                              line)
@@ -88,7 +90,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                 list.append(maj)
 
         if not list:
-            if "Elective" in line:
+            if "Elective" in line or "electives" in line:
                 return ["Elective"]
             return []
 
@@ -113,7 +115,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
         #TODO: Match with database credits
         #TODO: Dafault as 0.5 credits
         for course in list:
-            self.requirement.append(EngineeringMajorReq([course], 1, major, relatedMajor, additionalRequirement, 0.5))
+            self.requirement_dict[((course), 1, major, relatedMajor, additionalRequirement, 0.5)] += 1
 
     def get_table(self, data):
         tables = data.find_all("table")
@@ -143,8 +145,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
             list = self._course_list(req)
             if list:
                 credits = self._count_credits(list) / len(list) * number_additional
-                self.requirement.append(
-                    EngineeringMajorReq(list, number_additional, program, relatedMajor, term, credits))
+                self.requirement_dict[(tuple(list), number_additional, program, relatedMajor, term, credits)] += 1
 
     def load_file(self, file, year):
         """
@@ -201,8 +202,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                         list = self._course_list(self.get_text(tds[1]))
 
                     credits = self._count_credits(list)
-                    self.requirement.append(
-                        EngineeringMajorReq(list, 1, program, relatedMajor, term, credits))
+                    self.requirement_dict[(tuple(list), 1, program, relatedMajor, term, credits)] += 1
                     i+= 1
                     continue
                 elif "Work Term" in t:
@@ -229,8 +229,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                             list = self._course_list(t)
                             if list:
                                 credits = self._count_credits(list)/len(list)*number_additional
-                                self.requirement.append(
-                                    EngineeringMajorReq(list, number_additional, program, relatedMajor, term, credits))
+                                self.requirement_dict[(tuple(list), number_additional, program, relatedMajor, term, credits)] += 1
                             i += 1
                             continue
                         else:
@@ -255,8 +254,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                             list = self._course_list(line)
                             if list:
                                 credits = self._count_credits(list) / len(list) * number_additional
-                                self.requirement.append(
-                                    EngineeringMajorReq(list, number_additional, program, relatedMajor, term, credits))
+                                self.requirement_dict[(tuple(list), number_additional, program, relatedMajor, term, credits)] += 1
                             continue
                     else:
                         noOfCourse = 1
@@ -292,8 +290,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                             list = self._course_list(line)
                             if list:
                                 credits = self._count_credits(list) / len(list) * noOfCourse
-                                self.requirement.append(
-                                    EngineeringMajorReq(list, noOfCourse, program, relatedMajor, term, credits))
+                                self.requirement_dict[(tuple(list), noOfCourse, program, relatedMajor, term, credits)] += 1
                             continue
 
 
@@ -301,16 +298,8 @@ class EngineeringMajorParser2021_2022(MajorParser):
                         list = self._course_list(self.get_text(tds[0]))
                         if list:
                             credits = self._count_credits(list) / len(list) * noOfCourse
-                            self.requirement.append(
-                                EngineeringMajorReq(list, noOfCourse, program, relatedMajor, term, credits))
+                            self.requirement_dict[(tuple(list), noOfCourse, program, relatedMajor, term, credits)] += 1
                         i += 1
-
-
-
-
-
-
-
 
         else:
             i = 0
@@ -350,11 +339,7 @@ class EngineeringMajorParser2021_2022(MajorParser):
                     list = self._course_list(line)
                     if list:
                         credits = self._count_credits(list) / len(list) * number_additional
-                        self.requirement.append(
-                            EngineeringMajorReq(list, number_additional, program, relatedMajor, term, credits))
-
-
-
+                        self.requirement_dict[(tuple(list), number_additional, program, relatedMajor, term, credits)] += 1
                 i += 1
 
-
+        self.convert_dict_to_list(EngineeringMajorReq)

--- a/ProgramParsing/Engineering/MajorParser2021_2022.py
+++ b/ProgramParsing/Engineering/MajorParser2021_2022.py
@@ -201,8 +201,10 @@ class EngineeringMajorParser2021_2022(MajorParser):
                     else:
                         list = self._course_list(self.get_text(tds[1]))
 
-                    credits = self._count_credits(list)
-                    self.requirement_dict[(tuple(list), 1, program, relatedMajor, term, credits)] += 1
+                    # ECE 101A/B/C/D or WRKT has empty list
+                    if list:
+                        credits = self._count_credits(list)
+                        self.requirement_dict[(tuple(list), 1, program, relatedMajor, term, credits)] += 1
                     i+= 1
                     continue
                 elif "Work Term" in t:

--- a/ProgramParsing/Engineering/ParseProgram.py
+++ b/ProgramParsing/Engineering/ParseProgram.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # files = set(["/Specs//ENG-Environmental-Engineering.html"])
 
     #Multople TE does not display
-    # files = set(["/Specs/ENG-Mechatronics-Engineering.html"])
+    # files = set(["/Specs/2021-2022-ENG-Electrical-Engineering.html"])
 
     parsers = {
         'MajorParser': EngineeringMajorParser,

--- a/ProgramParsing/ProgramParser/ENV_VARIABLES/parse_years.py
+++ b/ProgramParsing/ProgramParser/ENV_VARIABLES/parse_years.py
@@ -13,4 +13,4 @@ CALENDAR_YEARS = ["2019-2020", "2020-2021", "2021-2022"]
 DEFAULT_YEAR = "2020-2021" # Refers to dict
 
 # For debuggin purposes:
-# CALENDAR_YEARS = ["2020-2021"]
+# CALENDAR_YEARS = ["2021-2022"]

--- a/ProgramParsing/ProgramParser/MajorParser.py
+++ b/ProgramParsing/ProgramParser/MajorParser.py
@@ -11,6 +11,7 @@ from ProgramParsing.Math.MajorReq import MajorReq
 from StringToNumber import StringToNumber
 import re
 import pkg_resources
+from collections import defaultdict
 
 
 class MajorParser:
@@ -19,6 +20,9 @@ class MajorParser:
         self.data = None
         self.requirement = []
         self.additionalRequirement = ""
+
+        # for eng factulty to catch duplcates
+        self.requirement_dict = defaultdict(int)
 
     def load_url(self, url):
         response = self.http.request('GET', url)
@@ -94,6 +98,14 @@ class MajorParser:
                 :return:
         """
         return pkg_resources.resource_string(__name__, str(year)+"_"+file)
+
+    def convert_dict_to_list(self, majorRequirements):
+        # If you use self.requirement_dict = defaultdict(int) to keep track of duplicated courses, you can use this function to convert into
+        # the standard list of reqs
+        self.requirement = []
+        for key in self.requirement_dict:
+            duplicate = self.requirement_dict[key]
+            self.requirement.append(majorRequirements(key[0], key[1] * duplicate, key[2], key[3], key[4], key[5] * duplicate))
 
     def __str__(self):
         output = ""


### PR DESCRIPTION
**Fixes**

Chemical Engineering has 4A CSE AND TE together as 1 instead of 3 (done)

Management Eng: electives missing for 4A and 4B (done)
Note for management engineering 2021-2022: elective may include Natural Science Elective

Mechtronics: Workterm report is part of stream 4 and 8 - also missing TEs (done)
Multiple TE lke chemical eng (in seperate columns)

Should we just remove wrkterm report cuz who cares? (ignored wrkterm)

Front end needs to handle Communication Elective case

ECE: Take out work term ECE 101(A,B,C,D)
